### PR TITLE
Fix tuple in for loop

### DIFF
--- a/src/tree/js.nim
+++ b/src/tree/js.nim
@@ -440,14 +440,15 @@ proc processCondtional(x: NimNode): NimNode =
     result &= nnkElse.newTree(quote do: newSeq[Element]())
 
 proc findLoopVars(x: NimNode): seq[NimNode] =
-  ## Returns a list of NimNodes that are variables in a loop
+  ## Returns a list of NimNodes that are variables in a loop.
+  ## e.g. `for a in someList` will return `a`
   case x.kind
   of nnkIdent:
     result &= x
   else:
     # TODO: Add proper checks before this explodes in our face
     for child in x:
-      result &= findLoopVars(x)
+      result &= findLoopVars(child)
 
 proc genericType(container, T: NimNode): NimNode =
   result = nnkBracketExpr.newTree(

--- a/tests/pages/compileTest.nim
+++ b/tests/pages/compileTest.nim
@@ -1,0 +1,18 @@
+# Series of tests that more check for compilation
+when defined(js):
+  import tree
+  import std/[dom, jscore, strformat]
+
+  proc App(): Element =
+    gui:
+      tdiv(id="tupleLoop"):
+        for (a, b) in [(1, 2), (3, 4)]:
+          p: fmt"{a} | {b}"
+else:
+  import utils
+  import std/strformat
+
+  proc tests*(d: FirefoxDriver) {.async.} =
+    test "Tuple loop runs correctly":
+      check d.selectorText("#tupleLoop p:nth-child(1)").await() == "1 | 2"
+      check d.selectorText("#tupleLoop p:nth-child(2)").await() == "3 | 4"

--- a/tests/pages/compileTest.nim
+++ b/tests/pages/compileTest.nim
@@ -8,6 +8,8 @@ when defined(js):
       tdiv(id="tupleLoop"):
         for (a, b) in [(1, 2), (3, 4)]:
           p: fmt"{a} | {b}"
+  App.renderTo("root")
+
 else:
   import utils
   import std/strformat

--- a/tests/pages/forLoop.nim
+++ b/tests/pages/forLoop.nim
@@ -54,8 +54,6 @@ when defined(js):
             p(class="item-3", style="color: blue"):
               text($i)
 
-
-
         # Test that when it rerenders, the loops don't go last
         # Can happen if prev() is wrong and returns nil when it shouldn't
         tdiv(id="prevNotLoop"):

--- a/tests/pages/forLoop.nim
+++ b/tests/pages/forLoop.nim
@@ -54,6 +54,8 @@ when defined(js):
             p(class="item-3", style="color: blue"):
               text($i)
 
+
+
         # Test that when it rerenders, the loops don't go last
         # Can happen if prev() is wrong and returns nil when it shouldn't
         tdiv(id="prevNotLoop"):

--- a/tests/testPages.nim
+++ b/tests/testPages.nim
@@ -66,6 +66,7 @@ testFile "Text Elements", "text.nim"
 testFile "For Loops", "forLoop.nim"
 testFile "If Expressions", "ifExpr.nim"
 testFile "Case Expressions", "caseExpr.nim"
+testFile "Compilation bugs", "compileTest.nim"
 
 # Clean up
 waitFor driver.close()


### PR DESCRIPTION
This code would go into an infinite loop and fail to compile
```nim
  proc App(): Element =
    gui:
      tdiv(id="tupleLoop"):
        for (a, b) in [(1, 2), (3, 4)]:
          p: fmt"{a} | {b}"
```
Issue was the code incorrectly just checking the same node instead of checking the children (on another note, why doesn't the unused var warning apply to loops/params?)